### PR TITLE
Fix start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build": "gatsby build",
     "dev": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
-    "start": "npm run develop",
+    "start": "npm run dev",
     "serve": "gatsby serve",
     "clean": "gatsby clean",
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"


### PR DESCRIPTION
Start script calls "npm run develop", but that does not exist.  This pull request renames the command from "npm run develop" to "npm run dev".